### PR TITLE
Add support for configuration file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(bsh-daemon
     src/daemon.cpp
     src/db.cpp
     src/git_utils.cpp
+    src/config.cpp
 )
 target_link_libraries(bsh-daemon PRIVATE SQLiteCpp PkgConfig::LIBGIT2)
 

--- a/scripts/bsh_init.zsh
+++ b/scripts/bsh_init.zsh
@@ -48,11 +48,24 @@ bindkey '^F' _bsh_toggle_success_filter
 zmodload zsh/net/socket
 zmodload zsh/datetime
 
-typeset -g _bsh_sock_path
-if [[ -n "$XDG_RUNTIME_DIR" ]]; then
-    _bsh_sock_path="$XDG_RUNTIME_DIR/bsh.sock"
-else
-    _bsh_sock_path="/tmp/bsh_$(id -u).sock"
+typeset -g _bsh_sock_path=""
+local _bsh_config_path=""
+if [[ -n "$XDG_CONFIG_HOME" ]]; then
+    _bsh_config_path="$XDG_CONFIG_HOME/bsh/config.toml"
+elif [[ -n "$HOME" ]]; then
+    _bsh_config_path="$HOME/.config/bsh/config.toml"
+fi
+
+if [[ -f "$_bsh_config_path" ]]; then
+    _bsh_sock_path=$(grep -E '^[[:space:]]*ipc_socket_path[[:space:]]*=' "$_bsh_config_path" | head -n 1 | awk -F'=' '{print $2}' | tr -d " '\"")
+fi
+
+if [[ -z "$_bsh_sock_path" ]]; then
+    if [[ -n "$XDG_RUNTIME_DIR" ]]; then
+        _bsh_sock_path="$XDG_RUNTIME_DIR/bsh.sock"
+    else
+        _bsh_sock_path="/tmp/bsh_$(id -u).sock"
+    fi
 fi
 
 _bsh_ensure_daemon() {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,0 +1,71 @@
+#include "config.hpp"
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <algorithm>
+#include <cstdlib>
+
+namespace fs = std::filesystem;
+
+std::string get_config_path() {
+    const char* xdg_config_home = std::getenv("XDG_CONFIG_HOME");
+    fs::path dir;
+
+    if (xdg_config_home && *xdg_config_home != '\0') {
+        dir = fs::path(xdg_config_home) / "bsh";
+    } else {
+        const char* home = std::getenv("HOME");
+        if (home) {
+            dir = fs::path(home) / ".config" / "bsh";
+        } else {
+            return "";
+        }
+    }
+    return (dir / "config.toml").string();
+}
+
+std::string trim(const std::string& str) {
+    auto start = str.find_first_not_of(" \t\r\n\"'");
+    if (start == std::string::npos) return "";
+    auto end = str.find_last_not_of(" \t\r\n\"'");
+    return str.substr(start, end - start + 1);
+}
+
+Config Config::load() {
+    Config config;
+    std::string config_path = get_config_path();
+    if (config_path.empty() || !fs::exists(config_path)) {
+        return config;
+    }
+
+    std::ifstream file(config_path);
+    if (!file.is_open()) {
+        return config;
+    }
+
+    std::string line;
+    while (std::getline(file, line)) {
+        auto comment_pos = line.find('#');
+        if (comment_pos != std::string::npos) {
+            line = line.substr(0, comment_pos);
+        }
+
+        auto eq_pos = line.find('=');
+        if (eq_pos != std::string::npos) {
+            std::string key = trim(line.substr(0, eq_pos));
+            std::string value = trim(line.substr(eq_pos + 1));
+
+            if (key == "db_path") {
+                config.db_path = value;
+            } else if (key == "max_suggestions") {
+                try {
+                    config.max_suggestions = std::stoi(value);
+                } catch (...) {}
+            } else if (key == "ipc_socket_path") {
+                config.ipc_socket_path = value;
+            }
+        }
+    }
+
+    return config;
+}

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -1,0 +1,10 @@
+#pragma once
+#include <string>
+
+struct Config {
+    std::string db_path;
+    int max_suggestions = 5;
+    std::string ipc_socket_path;
+
+    static Config load();
+};

--- a/src/daemon.cpp
+++ b/src/daemon.cpp
@@ -1,6 +1,7 @@
 #include "db.hpp"
 #include "git_utils.hpp"
 #include "ipc.hpp"
+#include "config.hpp"
 #include <string_view>
 #include <iostream>
 #include <vector>
@@ -134,16 +135,20 @@ void writer_thread_loop(const std::string& db_path) {
 int main(int argc, char* argv[]) {
     daemonize();
 
-    HistoryDB history(get_db_path());
+    Config config = Config::load();
+    std::string db_path = config.db_path.empty() ? get_db_path() : config.db_path;
+    int limit = config.max_suggestions;
+
+    HistoryDB history(db_path);
     history.initSchema();
 
-    std::thread writer_thread(writer_thread_loop, get_db_path());
+    std::thread writer_thread(writer_thread_loop, db_path);
     writer_thread.detach();
 
     int server_fd;
     struct sockaddr_un address;
     
-    std::string socket_path = get_socket_path();
+    std::string socket_path = config.ipc_socket_path.empty() ? get_socket_path() : config.ipc_socket_path;
     unlink(socket_path.c_str());
 
     if ((server_fd = socket(AF_UNIX, SOCK_STREAM, 0)) == 0) exit(EXIT_FAILURE);
@@ -214,7 +219,7 @@ int main(int argc, char* argv[]) {
                     header_text += " [OK] ";
                 }
 
-                auto results = history.search(query, scope, ctx_val, success);
+                auto results = history.search(query, scope, ctx_val, success, limit);
 
                 if (results.empty()) {
                     close(new_socket);

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -149,40 +149,40 @@ void HistoryDB::initSchema() {
         stmt_search_global_ = std::make_unique<SQLite::Statement>(*db_,
             "SELECT c.id, c.cmd_text FROM commands_fts fts "
             "JOIN commands c ON fts.rowid = c.id "
-            "WHERE commands_fts MATCH ? ORDER BY c.last_timestamp DESC LIMIT 5");
+            "WHERE commands_fts MATCH ? ORDER BY c.last_timestamp DESC LIMIT ?");
 
         stmt_search_global_ok_ = std::make_unique<SQLite::Statement>(*db_,
             "SELECT c.id, c.cmd_text FROM commands_fts fts "
             "JOIN commands c ON fts.rowid = c.id "
-            "WHERE commands_fts MATCH ? AND c.success_count > 0 ORDER BY c.last_timestamp DESC LIMIT 5");
+            "WHERE commands_fts MATCH ? AND c.success_count > 0 ORDER BY c.last_timestamp DESC LIMIT ?");
 
         stmt_search_dir_ = std::make_unique<SQLite::Statement>(*db_,
             "SELECT c.id, c.cmd_text FROM commands_fts fts "
             "JOIN commands c ON fts.rowid = c.id "
             "JOIN command_context ctx ON ctx.command_id = c.id "
             "WHERE commands_fts MATCH ? AND ctx.cwd = ? "
-            "GROUP BY c.id ORDER BY MAX(ctx.last_timestamp) DESC LIMIT 5");
+            "GROUP BY c.id ORDER BY MAX(ctx.last_timestamp) DESC LIMIT ?");
 
         stmt_search_dir_ok_ = std::make_unique<SQLite::Statement>(*db_,
             "SELECT c.id, c.cmd_text FROM commands_fts fts "
             "JOIN commands c ON fts.rowid = c.id "
             "JOIN command_context ctx ON ctx.command_id = c.id "
             "WHERE commands_fts MATCH ? AND ctx.cwd = ? AND ctx.success_count > 0 "
-            "GROUP BY c.id ORDER BY MAX(ctx.last_timestamp) DESC LIMIT 5");
+            "GROUP BY c.id ORDER BY MAX(ctx.last_timestamp) DESC LIMIT ?");
 
         stmt_search_branch_ = std::make_unique<SQLite::Statement>(*db_,
             "SELECT c.id, c.cmd_text FROM commands_fts fts "
             "JOIN commands c ON fts.rowid = c.id "
             "JOIN command_context ctx ON ctx.command_id = c.id "
             "WHERE commands_fts MATCH ? AND ctx.git_branch = ? "
-            "GROUP BY c.id ORDER BY MAX(ctx.last_timestamp) DESC LIMIT 5");
+            "GROUP BY c.id ORDER BY MAX(ctx.last_timestamp) DESC LIMIT ?");
 
         stmt_search_branch_ok_ = std::make_unique<SQLite::Statement>(*db_,
             "SELECT c.id, c.cmd_text FROM commands_fts fts "
             "JOIN commands c ON fts.rowid = c.id "
             "JOIN command_context ctx ON ctx.command_id = c.id "
             "WHERE commands_fts MATCH ? AND ctx.git_branch = ? AND ctx.success_count > 0 "
-            "GROUP BY c.id ORDER BY MAX(ctx.last_timestamp) DESC LIMIT 5");
+            "GROUP BY c.id ORDER BY MAX(ctx.last_timestamp) DESC LIMIT ?");
 
     } catch (std::exception& e) {
         std::cerr << "DB Init Error: " << e.what() << std::endl;
@@ -248,7 +248,8 @@ void HistoryDB::logCommand(const std::string& raw_cmd, const std::string& sessio
 std::vector<SearchResult> HistoryDB::search(const std::string& query, 
                                             SearchScope scope,
                                             const std::string& context_val,
-                                            bool only_success) {
+                                            bool only_success,
+                                            int limit) {
     std::vector<SearchResult> results;
     try {
         SQLite::Statement* stmt = nullptr;
@@ -258,12 +259,14 @@ std::vector<SearchResult> HistoryDB::search(const std::string& query,
             stmt = only_success ? stmt_search_global_ok_.get() : stmt_search_global_.get();
             stmt->reset();
             stmt->bind(1, fts_query);
+            stmt->bind(2, limit);
         }
         else if (scope == SearchScope::DIRECTORY) {
             stmt = only_success ? stmt_search_dir_ok_.get() : stmt_search_dir_.get();
             stmt->reset();
             stmt->bind(1, fts_query);
             stmt->bind(2, context_val);
+            stmt->bind(3, limit);
         }
         else if (scope == SearchScope::BRANCH) {
             stmt = only_success ? stmt_search_branch_ok_.get() : stmt_search_branch_.get();
@@ -271,6 +274,7 @@ std::vector<SearchResult> HistoryDB::search(const std::string& query,
             stmt->reset();
             stmt->bind(1, fts_query);
             stmt->bind(2, safe_branch);
+            stmt->bind(3, limit);
         }
 
         if (stmt) {

--- a/src/db.hpp
+++ b/src/db.hpp
@@ -23,7 +23,8 @@ public:
     std::vector<SearchResult> search(const std::string& query, 
                                      SearchScope scope,
                                      const std::string& context_val,
-                                     bool only_success = false); 
+                                     bool only_success = false,
+                                     int limit = 5);
 
 private:
     std::string db_path_;


### PR DESCRIPTION
Introduce a configuration file (config.toml) to customize the
daemon's behavior without requiring recompilation. The settings
exposed are db_path, max_suggestions, and ipc_socket_path. This
addresses the upstream issue regarding hardcoded config values.

Includes:
- C++ parser in src/config.hpp and src/config.cpp
- Integration into daemon.cpp to load and use settings
- Parameterized LIMIT clauses in db.cpp
- Shell script updates in bsh_init.zsh to parse config.toml
- CMakeLists.txt update for new source file

---
*PR created automatically by Jules for task [16378712907262175448](https://jules.google.com/task/16378712907262175448) started by @HanZhongyan01*